### PR TITLE
kill compile buffer to switch working dir.

### DIFF
--- a/cmake-build.el
+++ b/cmake-build.el
@@ -269,6 +269,11 @@ use Projectile to determine the root on a buffer-local basis, instead.")
       (message "Already building %s/%s"
                (projectile-project-name)
                (symbol-name cmake-build-profile))
+
+;    (with-current-buffer buffer-name
+;      (setq-local compilation-directory actual-directory)
+;      (setq-local default-directory actual-directory))
+    
     ;; close buffer, to reevaluate default dir, if dir-name has changed
     (if  (and (char-or-string-p buffer-name) (not (eq nil (get-buffer buffer-name))))
         (kill-buffer buffer-name)
@@ -279,7 +284,9 @@ use Projectile to determine the root on a buffer-local basis, instead.")
             (if did-split
                 (cons (list buffer-name #'display-buffer-no-window)
                       display-buffer-alist)
-              display-buffer-alist)))
+              display-buffer-alist))
+					;	   (actual-directory default-directory))
+	   )
       (let* ((compilation-buffer-name-function #'cmake-build--build-buffer-name))
         (cl-flet ((run-compile () (compile (concat "time " command) t)))
           (let ((w (get-buffer-window buffer-name t)))

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -451,8 +451,18 @@ use Projectile to determine the root on a buffer-local basis, instead.")
            (buffer-name (cmake-build--build-buffer-name)))
       (cmake-build--compile buffer-name "cmake --build . --target clean"))))
 
+(defun cmake-build--get-available-targets ()
+  (cmake-build--save-project-root ()
+    (let* ((default-directory (cmake-build--get-build-dir))
+           ;; cdr to skip the first line which is a cmake comment
+           (raw-targets-list (cdr (split-string (shell-command-to-string "cmake --build . --target help") "\n"))))
+      ;; the actual targets are after "... " in each string
+      (mapcar 'cadr (mapcar  (function (lambda (x) (split-string x " "))) raw-targets-list)))))
+
 (defun cmake-build-other-target (target-name)
-  (interactive "sTarget: ")
+  (interactive
+   (list
+    (completing-read "sTarget: " (cmake-build--get-available-targets))))
   (cmake-build--save-project-root ()
     (let* ((default-directory (cmake-build--get-build-dir))
            (buffer-name (cmake-build--build-buffer-name)))


### PR DESCRIPTION
I had an issue when the build directory changes, while the buffer name do not (with my own dir-name function that use git branch). The old remaining buffer have a default-directory associated that do not reflect the change in dir-name. killing this compilation buffer resolve the problem, but it's maybe not the best solution.
This PR changes `cmake-build--compile` so that :
- first check if compile buffer exists and have a process, so stop here
- if buffer exists and do not have a process kill it, so it's associated default-dir is forgotten
- then launch compile