### PR TITLE
generate and symlink compile_commands.json, close #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ A number of variables are available for customization:
 * `cmake-build-split-threshold`: (Default: 40%) Percentage after which the window will *not* be split; e.g. if the build window is set to 20, and the current window is 25, this is 80% of the current window.  By default, it would simply use the other window in this case.
 * `cmake-build-never-split`: (Default: nil) If set, this will *never* split the window, and just use the default.
 * `cmake-build-switch-to-build`: (Default: nil) If set, this will also make the build window current.  By default, it leaves the current window active.
+* `cmake-build-export-compile-commands`: (Default: nil) If set, this will ask cmake to export the compile commands during configuration, and create a symbolic link from project-root to the `compile_commands.json` file created in the build directory. __This will erase any previoulsy created `compile_commands.json` file in project-root directory__.
 
 ### Local settings
 

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -112,6 +112,11 @@ default, the name is in the form `build.<profile>`."
   :type 'function
   :group 'cmake-build)
 
+(defcustom cmake-build-export-compile-commands nil
+  "Ask cmake to generate compile_commands.json and to create a symlink in project-root."
+  :type 'boolean
+  :group 'cmake-build)
+
 ;;; These are very temporary and likely very host-specific variables,
 ;;; not something we want to constantly modify in custom.el
 (defvar cmake-build-profile 'clang-release
@@ -588,14 +593,15 @@ use Projectile to determine the root on a buffer-local basis, instead.")
              (buffer-name (cmake-build--build-buffer-name))
              (other-buffer-name (cmake-build--run-buffer-name))
              (command (concat "cmake " (cmake-build--get-cmake-options)
-                              " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+                              (when cmake-build-export-compile-commands " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
                               " " (car (cmake-build--get-profile))
                               " " (cmake-build--maybe-remote-project-root))))
         (when (file-exists-p "CMakeCache.txt")
           (delete-file "CMakeCache.txt"))
         (cmake-build--compile buffer-name command
                               :other-buffer-name other-buffer-name)
-        (cmake-build--create-compile-commands-symlink)))))
+        (when cmake-build-export-compile-commands
+          (cmake-build--create-compile-commands-symlink))))))
 
 (defun cmake-build-clean ()
   (interactive)


### PR DESCRIPTION
This PR ask cmake to generate compile_commands.json in build dir and create a symlink in project root.
So lsp and other source indexer can used compile_commands.json to do their job.

The modifications are extracted from my own repo, so please test/confirm it works (and is helpfull) before merge.
This PR should close #18 