### PR TITLE
Some new feature

### DIFF
--- a/cmake-build.el
+++ b/cmake-build.el
@@ -648,8 +648,8 @@ use Projectile to determine the root on a buffer-local basis, instead.")
              (other-buffer-name (cmake-build--run-buffer-name))
              (command (concat "cmake " (cmake-build--get-cmake-options)
                               (when cmake-build-export-compile-commands " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
-;;                              " -G\"CodeBlocks - Unix Makefiles\"" ;; For rt-run
-;;                              " -G\"CodeBlocks - Ninja\"" ;; For rt-run
+                              ;;                              " -G\"CodeBlocks - Unix Makefiles\"" ;; For rt-run
+                              ;;                              " -G\"CodeBlocks - Ninja\"" ;; For rt-run
                               " " (car (cmake-build--get-profile))
                               " " (cmake-build--maybe-remote-project-root))))
         (when (file-exists-p "CMakeCache.txt")
@@ -675,12 +675,12 @@ use Projectile to determine the root on a buffer-local basis, instead.")
            (raw-targets-list (split-string (shell-command-to-string "cmake --build . --target help") "\n"))
            (generator (if (string-match-p (regexp-quote "Makefile") (car raw-targets-list)) "Makefile" "Ninja"))
            (raw-targets-list (cdr raw-targets-list)))
-        (cond ((string= generator "Makefile")
-               ;; the actual targets are after "... " in each string
-               (mapcar 'cadr (mapcar  (function (lambda (x) (split-string x " "))) raw-targets-list)))
-              ((string= generator "Ninja")
-               ;; the actual targets are before ":" in each string
-               (mapcar 'car (mapcar  (function (lambda (x) (split-string x ":"))) raw-targets-list)))))))
+      (cond ((string= generator "Makefile")
+             ;; the actual targets are after "... " in each string
+             (mapcar 'cadr (mapcar  (function (lambda (x) (split-string x " "))) raw-targets-list)))
+            ((string= generator "Ninja")
+             ;; the actual targets are before ":" in each string
+             (mapcar 'car (mapcar  (function (lambda (x) (split-string x ":"))) raw-targets-list)))))))
 
 (defun cmake-build-other-target (target-name)
   (interactive

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -307,8 +307,8 @@ use Projectile to determine the root on a buffer-local basis, instead.")
               (cmake-build--get-configs))))
 
 (defun cmake-build--get-build-config (&optional config)
-  (let ((config (cmake-build--get-config config)))
-    (cdr (assoc :build config))))
+  (let* ((config (cmake-build--get-config config)))
+    (or (cdr (assoc :build config)) '("all"))))
 
 (defun cmake-build--get-run-config (&optional config)
   (let ((config (cmake-build--get-config config)))

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -312,6 +312,12 @@ use Projectile to determine the root on a buffer-local basis, instead.")
   (let ((config (cmake-build--get-config config)))
     (cdr (assoc :env config))))
 
+(defun cmake-build--get-run-config-dirtype (&optional config)
+  (let* ((config (cmake-build--get-config config))
+         (dirtype (cdr (assoc :dirtype config))))
+    (if dirtype
+        (car dirtype)
+      "build")))
 (defun cmake-build--get-other-targets ()
   (cdr (assoc 'cmake-build-other-targets (cmake-build--get-project-data))))
 
@@ -455,7 +461,10 @@ use Projectile to determine the root on a buffer-local basis, instead.")
     (let* ((cmake-build-run-config config)
            (config (cmake-build--get-run-config))
            (command (cmake-build--get-run-command config))
-           (default-directory (cmake-build--get-build-dir (car config)))
+           (dirtype (cmake-build--get-run-config-dirtype))
+           (default-directory (cond ((string= dirtype "build") (cmake-build--get-build-dir (car config)))
+                     ((string= dirtype "source") (concat (cmake-build--maybe-remote-project-root) (car config)))
+                     ((string= dirtype "abs") (car config))))
            (process-environment (append
                                  (list (concat "PROJECT_ROOT="
                                                (cmake-build--maybe-remote-project-root)))

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -648,7 +648,8 @@ use Projectile to determine the root on a buffer-local basis, instead.")
              (other-buffer-name (cmake-build--run-buffer-name))
              (command (concat "cmake " (cmake-build--get-cmake-options)
                               (when cmake-build-export-compile-commands " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
-                              " -G\"CodeBlocks - Unix Makefiles\"" ;; For rt-run
+;;                              " -G\"CodeBlocks - Unix Makefiles\"" ;; For rt-run
+;;                              " -G\"CodeBlocks - Ninja\"" ;; For rt-run
                               " " (car (cmake-build--get-profile))
                               " " (cmake-build--maybe-remote-project-root))))
         (when (file-exists-p "CMakeCache.txt")

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -634,6 +634,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
              (other-buffer-name (cmake-build--run-buffer-name))
              (command (concat "cmake " (cmake-build--get-cmake-options)
                               (when cmake-build-export-compile-commands " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
+                              " -G\"CodeBlocks - Unix Makefiles\"" ;; For rt-run
                               " " (car (cmake-build--get-profile))
                               " " (cmake-build--maybe-remote-project-root))))
         (when (file-exists-p "CMakeCache.txt")

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -125,6 +125,10 @@ default, the name is in the form `build.<profile>`."
 (defvar cmake-build-options ""
   "Additional build options passed to cmake.  For example, \"-j 7\" for parallel builds.")
 
+(defvar cmake-build-tool-options ""
+  "Additional build options passed to build tool, after -- .  For example, \"-l 4\" for make load builds.")
+
+
 (defvar cmake-build-run-config nil
   "Set name for cmake-build run, specifying the target run-config name.  Run configurations are a
 path, command, and arguments for a particular run.")
@@ -209,11 +213,13 @@ use Projectile to determine the root on a buffer-local basis, instead.")
     (let* ((form (read (buffer-string)))
            (build-profile (cadr (assoc :build-profile form)))
            (build-options (cadr (assoc :build-options form)))
+           (build-tool-options (cadr (assoc :build-tool-options form)))
            (build-run-config (cadr (assoc :build-run-config form)))
            (build-project-root (cadr (assoc :build-project-root form)))
            (build-roots (cadr (assoc :build-roots form))))
       (setq cmake-build-profile (or build-profile cmake-build-profile))
       (setq cmake-build-options (or build-options cmake-build-options))
+      (setq cmake-build-tool-options (or build-tool-options cmake-build-tool-options))
       (setq cmake-build-run-config (or build-run-config cmake-build-run-config))
       (setq cmake-build-project-root (or build-project-root cmake-build-project-root))
       (setq cmake-build-build-roots (or build-roots cmake-build-build-roots)))))
@@ -227,6 +233,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
   (cmake-build--with-options-file (:writep t)
     (print `((:build-profile ,cmake-build-profile)
              (:build-options ,cmake-build-options)
+             (:build-tool-options ,cmake-build-tool-options)
              (:build-run-config ,cmake-build-run-config)
              (:build-project-root ,cmake-build-project-root)
              (:build-roots ,cmake-build-build-roots))
@@ -445,7 +452,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
     (cmake-build--save-project-root ()
       (let* ((default-directory (cmake-build--get-build-dir))
              (config (cmake-build--get-build-config))
-             (command (concat "cmake --build . " cmake-build-options " --target " (car config)))
+             (command (concat "cmake --build . " cmake-build-options " --target " (car config) " -- " cmake-build-tool-options))
              (buffer-name (cmake-build--build-buffer-name))
              (other-buffer-name (cmake-build--run-buffer-name)))
         (cmake-build--compile buffer-name command
@@ -543,6 +550,13 @@ use Projectile to determine the root on a buffer-local basis, instead.")
    (list
     (read-string "CMake build options: " cmake-build-options)))
   (setq cmake-build-options option-string))
+
+
+(defun cmake-build-set-tool-options (option-string)
+  (interactive
+   (list
+    (read-string "CMake build tool options: " cmake-build-tool-options)))
+  (setq cmake-build-tool-options option-string))
 
 (defun cmake-build-set-config (config-name)
   (interactive
@@ -670,7 +684,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
            (buffer-name (cmake-build--build-buffer-name))
            (other-buffer-name (cmake-build--run-buffer-name)))
       (cmake-build--compile buffer-name
-                            (concat "cmake --build . " cmake-build-options " --target " target-name)
+                            (concat "cmake --build . " cmake-build-options " --target " target-name " -- " cmake-build-tool-options)
                             :other-buffer-name other-buffer-name))))
 
 

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -571,6 +571,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
 
 (defun cmake-build-run-cmake ()
   (interactive)
+  (cmake-build--save-project-root ()
   (let* ((default-directory (cmake-build--get-build-dir))
          (buffer-name (cmake-build--build-buffer-name))
          (other-buffer-name (cmake-build--run-buffer-name)))

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -128,7 +128,6 @@ default, the name is in the form `build.<profile>`."
 (defvar cmake-build-tool-options ""
   "Additional build options passed to build tool, after -- .  For example, \"-l 4\" for make load builds.")
 
-
 (defvar cmake-build-run-config nil
   "Set name for cmake-build run, specifying the target run-config name.  Run configurations are a
 path, command, and arguments for a particular run.")
@@ -325,6 +324,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
     (if dirtype
         (car dirtype)
       "build")))
+
 (defun cmake-build--get-other-targets ()
   (cdr (assoc 'cmake-build-other-targets (cmake-build--get-project-data))))
 

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -273,7 +273,7 @@ path, command, and arguments for a particular run.")
           config)))
 
 (defun cmake-build--set-build-root (path)
-  (when (cmake-build--build-root)
+  (when (cmake-build--project-root)
     (setf (alist-get (intern (cmake-build--project-root)) cmake-build-build-roots)
           path)))
 
@@ -354,8 +354,9 @@ path, command, and arguments for a particular run.")
   (cdr (assoc 'cmake-build-other-targets (cmake-build--get-project-data))))
 
 (defun cmake-build--build-root ()
+  (when (cmake-build--project-root)
   (or (cdr (assoc (intern (cmake-build--project-root)) cmake-build-build-roots))
-      (cmake-build--project-root)))
+      (cmake-build--project-root))))
 
 (defun cmake-build--source-root ()
   (cadr (assoc 'cmake-build-source-root (cmake-build--get-project-data))))
@@ -364,11 +365,12 @@ path, command, and arguments for a particular run.")
   (concat "build." profile))
 
 (defun cmake-build--get-build-dir (&optional subdir)
-  (concat (cmake-build--build-root)
-          (funcall cmake-build-dir-name-function
-                   (cmake-build--project-root)
-                   (symbol-name cmake-build-profile))
-          "/" (or subdir "")))
+  (when (cmake-build--build-root)
+    (concat (cmake-build--build-root)
+            (funcall cmake-build-dir-name-function
+                     (cmake-build--project-root)
+                     (symbol-name cmake-build-profile))
+            "/" (or subdir ""))))
 
 (defun cmake-build--check-build-dir ()
   (let ((path (cmake-build--get-build-dir)))
@@ -695,6 +697,7 @@ path, command, and arguments for a particular run.")
                               :other-buffer-name other-buffer-name)
         (when cmake-build-export-compile-commands
           (cmake-build--create-compile-commands-symlink))))))
+
 
 (defun cmake-build-clean ()
   (interactive)

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -114,7 +114,8 @@ default, the name is in the form `build.<profile>`."
   :group 'cmake-build)
 
 (defcustom cmake-build-export-compile-commands nil
-  "Ask cmake to generate compile_commands.json and to create a symlink in project-root."
+  "Ask cmake to generate compile_commands.json
+   and create a symlink in project-root."
   :type 'boolean
   :group 'cmake-build)
 
@@ -134,8 +135,9 @@ default, the name is in the form `build.<profile>`."
 path, command, and arguments for a particular run.")
 
 (defvar cmake-build-project-root nil
-  "Optionally, set this to the emacs-wide root of the current project.  Setting this to NIL will
-use Projectile to determine the root on a buffer-local basis, instead.")
+  "Optionally, set this to the emacs-wide root of the current project.
+ Setting this to NIL will use Projectile to determine the root
+ on a buffer-local basis, instead.")
 
 (defvar cmake-build-build-roots nil
   "This is an alist of build roots per-project, for out-of-source building.")

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -1,11 +1,13 @@
-;;; -*- lexical-binding: t; -*-
-;;; cmake-build.el --- Handle cmake build profiles and target/run configurations for projects
+;;; cmake-build.el --- Handle cmake build profiles and target/run configurations for projects -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019-2020  Ryan Pavlik
 
 ;; Author: Ryan Pavlik <rpavlik@gmail.com>
 ;; URL: https://github.com/rpav/cmake-build.el
 ;; Version: 1.0
+;; Package-Requires: ((cl-lib "1.0")(tramp "1.0"))
+
+;; 2025 dlyr
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -625,12 +625,22 @@ path, command, and arguments for a particular run.")
 
 (defun cmake-build-run-cmake ()
   (interactive)
-  (cmake-build--save-project-root ()
-    (let* ((default-directory (cmake-build--get-build-dir))
-           (buffer-name (cmake-build--build-buffer-name))
-           (other-buffer-name (cmake-build--run-buffer-name)))
-      (cmake-build--compile buffer-name "cmake ."
-                          :other-buffer-name other-buffer-name))))
+  (let ((build-dir (cmake-build--get-build-dir)))
+    (unless (file-exists-p build-dir)
+      (make-directory build-dir t))
+    (cmake-build--save-project-root ()
+      (let* ((default-directory (cmake-build--get-build-dir))
+             (buffer-name (cmake-build--build-buffer-name))
+             (other-buffer-name (cmake-build--run-buffer-name))
+             (command (concat "cmake " (cmake-build--get-cmake-options)
+                              (when cmake-build-export-compile-commands " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
+                              " " (car (cmake-build--get-profile))
+                              " " (cmake-build--maybe-remote-project-root))))
+        (cmake-build--compile buffer-name command
+                              :other-buffer-name other-buffer-name)
+        (when cmake-build-export-compile-commands
+          (cmake-build--create-compile-commands-symlink))))))
+
 
 (defun cmake-build--create-compile-commands-symlink ()
   (let ((filename (expand-file-name "compile_commands.json" (cmake-build--project-root))))
@@ -653,7 +663,12 @@ path, command, and arguments for a particular run.")
                               " " (car (cmake-build--get-profile))
                               " " (cmake-build--maybe-remote-project-root))))
         (when (file-exists-p "CMakeCache.txt")
+          (message "delete CMakeCache.txt")
           (delete-file "CMakeCache.txt"))
+        (when (file-directory-p "CMakeFiles")
+          (message "delete CMakeFiles")
+          (delete-directory "CMakeFiles" 't))
+
         (cmake-build--compile buffer-name command
                               :other-buffer-name other-buffer-name)
         (when cmake-build-export-compile-commands

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -279,7 +279,7 @@ path, command, and arguments for a particular run.")
   (let ((default-directory (cmake-build--project-root)))
     (projectile-project-name)))
 
-(defun cmake-build--build-buffer-name (&optional name)
+(defun cmake-build--build-buffer-name ()
   (concat "*Build " (cmake-build-project-name) "/" (symbol-name cmake-build-profile) ": " (symbol-name (cmake-build-get-run-config-name)) "*"))
 
 (defun cmake-build--run-buffer-name ()
@@ -393,7 +393,6 @@ path, command, and arguments for a particular run.")
 
 (defun cmake-build--popup-buffer (name other-name)
   (let* ((buffer (get-buffer-create name))
-         (current-buffer-window (get-buffer-window buffer t))
          (other-buffer-window (and other-name (get-buffer-window other-name t)))
          (buffer-config-name (cmake-build-get-run-config-name)))
     (unless (cmake-build--switch-to-buffer buffer (get-buffer-window buffer t) other-buffer-window)
@@ -529,7 +528,7 @@ path, command, and arguments for a particular run.")
            (lambda (process event)
              (let* ((this-root this-root)
                     (cmake-build-project-root this-root))
-               (when (equalp "finished\n" event)
+               (when (cl-equalp "finished\n" event)
                  (cmake-build--invoke-run this-run-config)))))
         (cmake-build--invoke-run this-run-config)))))
 
@@ -598,7 +597,7 @@ path, command, and arguments for a particular run.")
    (list
     (let* ((default-directory (cmake-build--build-root)))
       (read-directory-name "CMake Build build root (blank to unset): "))))
-  (if (equalp "" path)
+  (if (cl-equalp "" path)
       (progn
         (message "Build root reset to default")
         (cmake-build--set-build-root nil))
@@ -651,8 +650,6 @@ path, command, and arguments for a particular run.")
              (other-buffer-name (cmake-build--run-buffer-name))
              (command (concat "cmake " (cmake-build--get-cmake-options)
                               (when cmake-build-export-compile-commands " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
-                              ;;                              " -G\"CodeBlocks - Unix Makefiles\"" ;; For rt-run
-                              ;;                              " -G\"CodeBlocks - Ninja\"" ;; For rt-run
                               " " (car (cmake-build--get-profile))
                               " " (cmake-build--maybe-remote-project-root))))
         (when (file-exists-p "CMakeCache.txt")

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -144,6 +144,28 @@ path, command, and arguments for a particular run.")
 
 (defvar cmake-build-run-keymap (make-sparse-keymap))
 
+(defun cmake-build--print-variable(var)
+  (message "cmake-build %s: %s" var (eval var))
+  )
+
+(defun cmake-build-print-project-infos ()
+  (interactive)
+  (message "*** cmake-build project variables ***")
+  (cmake-build--print-variable 'cmake-build-profile)
+  (cmake-build--print-variable 'cmake-build-options)
+  (cmake-build--print-variable 'cmake-build-tool-options)
+  (cmake-build--print-variable 'cmake-build-run-config)
+  (cmake-build--print-variable 'cmake-build-project-root)
+  (message "*** cmake-build project configuration ***")
+  (cmake-build--project-root)
+  (if (cmake-build--project-root)
+      (message "cmake-build--project-root: %s" (cmake-build--project-root))
+    (message "cmake-build--project-root: nil"))
+  (if (cmake-build--get-build-dir)   
+      (message "cmake-build--get-build-dir: %s" (cmake-build--get-build-dir))
+    (message "cmake-build--get-build-dir: nil"))
+  (message "*** end cmake-build project information ***"))
+
 (defun cmake-build-quit-window ()
   (interactive)
   (when (and cmake-build-quit-kills-process

--- a/cmake-build.el
+++ b/cmake-build.el
@@ -31,6 +31,7 @@
   (expand-file-name "cmake-build-options.el" user-emacs-directory)
   "Path to file storing local cmake-build settings, such as options
 passed to cmake, and the current config."
+  :type 'file
   :group 'cmake-build)
 
 (defcustom cmake-build-run-window-autoswitch t
@@ -261,7 +262,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
 
 (defun cmake-build--validate (&optional tag)
   (not
-   (case (cmake-build--validity)
+   (cl-case (cmake-build--validity)
      (:build-dir-missing
       (message "cmake-build %s: No build dir (%s)\nDo you need to initialize CMake?"
                (or tag "compile")
@@ -400,7 +401,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
     t))
 
 (defun cmake-build--display-buffer (name &optional other-name)
-  (case cmake-build-display-type
+  (cl-case cmake-build-display-type
     (split (cmake-build--split-to-buffer name other-name))
     (frame (cmake-build--popup-buffer name other-name))))
 
@@ -770,7 +771,7 @@ use Projectile to determine the root on a buffer-local basis, instead.")
    `(keymap "CMake Build: Settings" ,@(cmake-build--menu-settings))))
 
 (defun cmake-build--menu-action-dispatch (action)
-  (case (car action)
+  (cl-case (car action)
     (:info (message "Project root: %s" (cmake-build--project-root)))
     (:debug (cmake-build-debug))
     (:build (cmake-build-current))


### PR DESCRIPTION
Here are the actual version I use for a while, with some new feature

* allow to specify if executable path is in source, install, or absolute
* generate code block to have target executable list (I use it with rt-run.el)
* add tool option custom 
* use "all" when no target is specified
* check if generator is Makefile or Ninja to retrieve build target list

Maybe some modification are too "personal" feel free to ask me to clean/update/generalize some of them.